### PR TITLE
Add federationLink to groups

### DIFF
--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkEntity.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkEntity.java
@@ -1,0 +1,79 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.models.jpa.entities.GroupEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "GROUP_FEDERATION_LINK", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "GROUP_ID" })
+})
+@NamedQueries({
+        @NamedQuery(name = "findByFederationLink", query = "select t from GroupFederationLinkEntity t where t.federationLink = :federationLink"),
+        @NamedQuery(name = "findByGroupId", query = "select t from GroupFederationLinkEntity t where t.groupId = :groupId"),
+        @NamedQuery(name = "findGroupsByFederationLinkAndName", query = "select g from GroupFederationLinkEntity gl, GroupEntity g where gl.groupId = g.id and g.name like concat('%',:name,'%') and gl.federationLink = :federationLink"),
+        @NamedQuery(name = "findGroupsByFederationLink", query = "select g from GroupFederationLinkEntity gl, GroupEntity g where gl.groupId = g.id and gl.federationLink = :federationLink"),
+})
+public class GroupFederationLinkEntity {
+
+    @Id
+    @Column(name = "GROUP_ID", nullable = false)
+    private String groupId;
+
+    @Column(name = "FEDERATION_LINK", nullable = false)
+    private String federationLink;
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getFederationLink() {
+        return federationLink;
+    }
+
+    public void setFederationLink(String federationLink) {
+        this.federationLink = federationLink;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((groupId == null) ? 0 : groupId.hashCode());
+        result = prime * result + ((federationLink == null) ? 0 : federationLink.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GroupFederationLinkEntity other = (GroupFederationLinkEntity) obj;
+        if (groupId == null) {
+            if (other.groupId != null)
+                return false;
+        } else if (!groupId.equals(other.groupId))
+            return false;
+        if (federationLink == null) {
+            if (other.federationLink != null)
+                return false;
+        } else if (!federationLink.equals(other.federationLink))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkJpaEntityProvider.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkJpaEntityProvider.java
@@ -1,0 +1,28 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+import java.util.Collections;
+import java.util.List;
+
+public class GroupFederationLinkJpaEntityProvider implements JpaEntityProvider {
+
+    @Override
+    public List<Class<?>> getEntities() {
+        return Collections.<Class<?>>singletonList(GroupFederationLinkEntity.class);
+    }
+
+    @Override
+    public String getChangelogLocation() {
+        return "META-INF/group-federation-changelog.xml";
+    }
+
+    @Override
+    public String getFactoryId() {
+        return GroupFederationLinkJpaEntityProviderFactory.ID;
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkJpaEntityProviderFactory.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupFederationLinkJpaEntityProviderFactory.java
@@ -1,0 +1,34 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class GroupFederationLinkJpaEntityProviderFactory implements JpaEntityProviderFactory {
+    protected static final String ID = "group-federation-entity-provider";
+
+    @Override
+    public JpaEntityProvider create(KeycloakSession session) {
+        return new GroupFederationLinkJpaEntityProvider();
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkAdminResource.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkAdminResource.java
@@ -1,0 +1,133 @@
+package com.scality.keycloak.groupFederationLink;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.annotations.cache.NoCache;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.jpa.entities.GroupEntity;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.GroupsResource;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import org.keycloak.services.resources.admin.permissions.GroupPermissionEvaluator;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public class GroupWithLinkAdminResource {
+    protected static final Logger logger = Logger.getLogger(GroupWithLinkAdminResource.class);
+    protected final AdminPermissionEvaluator auth;
+    protected final KeycloakSession session;
+    private GroupsResource groupsResource;
+
+    public GroupWithLinkAdminResource(KeycloakSession session, AdminPermissionEvaluator auth,
+            AdminEventBuilder adminEvent) {
+        this.groupsResource = new GroupsResource(session.getContext().getRealm(), session, auth,
+                adminEvent.resource(ResourceType.GROUP));
+        this.session = session;
+        this.auth = auth;
+    }
+
+    /***
+     * 
+     * @return EntityManager
+     */
+    private EntityManager getEntityManager() {
+        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.GROUPS)
+    @Operation(summary = "Get groups")
+    public Stream<GroupWithLinkRepresentation> getGroupsWithLink(@QueryParam("search") String search,
+            @QueryParam("link") String federationLink,
+            @QueryParam("exact") @DefaultValue("false") Boolean exact,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults) {
+
+        GroupPermissionEvaluator groupsEvaluator = auth.groups();
+        groupsEvaluator.requireList();
+        logger.info("getGroupsWithLink");
+
+        if (Objects.isNull(federationLink) || federationLink.isEmpty()) {
+            Stream<GroupRepresentation> groups = groupsResource.getGroups(search, search, exact, firstResult,
+                    maxResults, true, true);
+
+            return groups.map(group -> {
+                GroupWithLinkRepresentation groupWithLink = new GroupWithLinkRepresentation();
+                groupWithLink.setId(group.getId());
+                groupWithLink.setName(group.getName());
+                groupWithLink.setPath(group.getPath());
+                groupWithLink.setParentId(group.getParentId());
+                groupWithLink.setSubGroupCount(group.getSubGroupCount());
+                groupWithLink.setSubGroups(group.getSubGroups());
+                groupWithLink.setAttributes(group.getAttributes());
+                groupWithLink.setRealmRoles(group.getRealmRoles());
+                groupWithLink.setClientRoles(group.getClientRoles());
+
+                try {
+                    GroupFederationLinkEntity groupFederationLinkEntity = getEntityManager()
+                            .createNamedQuery("findByGroupId", GroupFederationLinkEntity.class)
+                            .setParameter("groupId", group.getId())
+                            .getSingleResult();
+                    groupWithLink.setFederationLink(groupFederationLinkEntity.getFederationLink());
+                } catch (NoResultException e) {
+                    logger.trace("No federation link found for group " + group.getId(), e);
+                }
+
+                return groupWithLink;
+            });
+        }
+
+        try {
+            if (Objects.isNull(search) || search.isEmpty()) {
+                List<GroupEntity> resultList = getEntityManager()
+                        .createNamedQuery("findGroupsByFederationLink", GroupEntity.class)
+                        .setParameter("federationLink", federationLink).getResultList();
+                return resultList.stream().map(groupEntity -> {
+                    GroupWithLinkRepresentation groupFederationLinkEntity = new GroupWithLinkRepresentation();
+                    groupFederationLinkEntity.setId(groupEntity.getId());
+                    groupFederationLinkEntity.setName(groupEntity.getName());
+                    groupFederationLinkEntity.setParentId(groupEntity.getParentId());
+                    groupFederationLinkEntity.setFederationLink(federationLink);
+                    return groupFederationLinkEntity;
+                });
+            }
+
+            List<GroupEntity> resultList = getEntityManager()
+                    .createNamedQuery("findGroupsByFederationLinkAndName", GroupEntity.class)
+                    .setParameter("federationLink", federationLink)
+                    .setParameter("name", search)
+                    .getResultList();
+            return resultList.stream().map(groupEntity -> {
+                GroupWithLinkRepresentation groupFederationLinkEntity = new GroupWithLinkRepresentation();
+                groupFederationLinkEntity.setId(groupEntity.getId());
+                groupFederationLinkEntity.setName(groupEntity.getName());
+                groupFederationLinkEntity.setParentId(groupEntity.getParentId());
+                groupFederationLinkEntity.setFederationLink(federationLink);
+                return groupFederationLinkEntity;
+            });
+        } catch (NoResultException e) {
+            logger.trace("No group found for federation link " + federationLink, e);
+            return Stream.empty();
+        }
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkAdminResourceProvider.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkAdminResourceProvider.java
@@ -1,0 +1,43 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider;
+import org.keycloak.services.resources.admin.ext.AdminRealmResourceProviderFactory;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+
+public class GroupWithLinkAdminResourceProvider
+        implements AdminRealmResourceProviderFactory, AdminRealmResourceProvider {
+
+    @Override
+    public AdminRealmResourceProvider create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return "groups-with-link";
+    }
+
+    @Override
+    public Object getResource(KeycloakSession session, RealmModel realm, AdminPermissionEvaluator auth,
+            AdminEventBuilder adminEvent) {
+        return new GroupWithLinkAdminResource(session, auth, adminEvent);
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -6,8 +6,6 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.jpa.entities.GroupAttributeEntity;
-import org.keycloak.models.jpa.entities.GroupEntity;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -1,0 +1,44 @@
+package com.scality.keycloak.groupFederationLink;
+
+import java.util.Collections;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.jpa.entities.GroupAttributeEntity;
+import org.keycloak.models.jpa.entities.GroupEntity;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
+
+import jakarta.persistence.EntityManager;
+
+public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
+
+    public GroupWithLinkLDAPStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider,
+            GroupLDAPStorageMapperFactory factory) {
+        super(mapperModel, ldapProvider, factory);
+    }
+
+    /***
+     * 
+     * @return EntityManager
+     */
+    private EntityManager getEntityManager() {
+        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @Override
+    protected GroupModel createKcGroup(RealmModel realm, String ldapGroupName, GroupModel parentGroup) {
+        GroupModel groupModel = super.createKcGroup(realm, ldapGroupName, parentGroup);
+
+        GroupFederationLinkEntity groupFederationLinkEntity = new GroupFederationLinkEntity();
+        groupFederationLinkEntity.setGroupId(groupModel.getId());
+        groupFederationLinkEntity.setFederationLink(ldapProvider.getModel().getId());
+        getEntityManager().persist(groupFederationLinkEntity);
+
+        return groupModel;
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
@@ -1,0 +1,20 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.mappers.AbstractLDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
+
+public class GroupWithLinkLDAPStorageMapperFactory extends GroupLDAPStorageMapperFactory {
+    @Override
+    protected AbstractLDAPStorageMapper createMapper(ComponentModel mapperModel,
+            LDAPStorageProvider federationProvider) {
+        return new GroupWithLinkLDAPStorageMapper(mapperModel, federationProvider, this);
+    }
+
+    @Override
+    public String getId() {
+        return "group-with-link-ldap-mapper";
+    }
+
+}

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkRepresentation.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkRepresentation.java
@@ -1,0 +1,41 @@
+package com.scality.keycloak.groupFederationLink;
+
+import org.keycloak.representations.idm.GroupRepresentation;
+
+public class GroupWithLinkRepresentation extends GroupRepresentation {
+    protected String federationLink;
+
+    public String getFederationLink() {
+        return federationLink;
+    }
+
+    public void setFederationLink(String federationLink) {
+        this.federationLink = federationLink;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((federationLink == null) ? 0 : federationLink.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GroupWithLinkRepresentation other = (GroupWithLinkRepresentation) obj;
+        if (federationLink == null) {
+            if (other.federationLink != null)
+                return false;
+        } else if (!federationLink.equals(other.federationLink))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/resources/META-INF/group-federation-changelog.xml
+++ b/src/main/resources/META-INF/group-federation-changelog.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet author="Jean-Baptiste WATENBERG" id="group-federation-link-1.0">
+
+        <createTable tableName="GROUP_FEDERATION_LINK">
+            <column name="GROUP_ID" type="VARCHAR(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="FEDERATION_LINK" type="VARCHAR(36)">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <createIndex indexName="group_federation_link_group_id" tableName="GROUP_FEDERATION_LINK">
+            <column name="GROUP_ID" />
+        </createIndex>
+
+        <createIndex indexName="group_federation_link_federation_link"
+            tableName="GROUP_FEDERATION_LINK">
+            <column name="FEDERATION_LINK" />
+        </createIndex>
+
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/META-INF/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
@@ -1,1 +1,2 @@
 com.scality.keycloak.truststore.TruststoreJpaEntityProviderFactory
+com.scality.keycloak.groupFederationLink.GroupFederationLinkJpaEntityProviderFactory

--- a/src/main/resources/META-INF/services/org.keycloak.services.resources.admin.ext.AdminRealmResourceProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.services.resources.admin.ext.AdminRealmResourceProviderFactory
@@ -1,1 +1,2 @@
 com.scality.keycloak.truststore.TruststoreAdminResourceProvider
+com.scality.keycloak.groupFederationLink.GroupWithLinkAdminResourceProvider

--- a/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
@@ -1,0 +1,1 @@
+com.scality.keycloak.groupFederationLink.GroupWithLinkLDAPStorageMapperFactory

--- a/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
+++ b/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
@@ -1,0 +1,375 @@
+package com.scality.keycloak;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.AccessTokenResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.MountableFile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scality.keycloak.groupFederationLink.GroupWithLinkRepresentation;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+
+record ProviderAndMapper(String providerID, String mapperID) {
+}
+
+public class GroupWithLinkTest {
+
+    private Logger logger = LoggerFactory.getLogger(GroupWithLinkTest.class);
+
+    private String getToken(KeycloakContainer keycloak) {
+        Keycloak keycloakClient = keycloak.getKeycloakAdminClient();
+        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
+        return accessTokenResponse.getToken();
+    }
+
+    private ProviderAndMapper createLdapConfigurationAndLdapGroupMapper(KeycloakContainer keycloak) throws IOException {
+        /// Retrieve Master realm id
+        URL urlMasterRealm = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master");
+        HttpURLConnection connMasterRealm = (HttpURLConnection) urlMasterRealm.openConnection();
+        connMasterRealm.setRequestMethod("GET");
+        connMasterRealm.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+        int responseCodeMasterRealm = connMasterRealm.getResponseCode();
+        if (responseCodeMasterRealm != 200) {
+            System.out.println("Get Master Realm responseCode = " + responseCodeMasterRealm);
+            InputStream errorStream = connMasterRealm.getErrorStream();
+            if (errorStream != null) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = errorStream.read(buffer)) != -1) {
+                    System.out.write(buffer, 0, bytesRead);
+                }
+            }
+        }
+        String responsePayloadMasterRealm = IOUtils.toString(connMasterRealm.getInputStream(), "UTF-8");
+        // Todo parse json
+        String masterRealmId = responsePayloadMasterRealm.substring(responsePayloadMasterRealm.indexOf("id") + 5,
+                responsePayloadMasterRealm.indexOf("realm") - 3);
+
+        URL url = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/components");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        conn.getOutputStream().write(
+                ("{\n" + //
+                        "  \"config\": {\n" + //
+                        "    \"enabled\": [\n" + //
+                        "      \"true\"\n" + //
+                        "    ],\n" + //
+                        "    \"vendor\": [\n" + //
+                        "      \"other\"\n" + //
+                        "    ],\n" + //
+                        "    \"connectionUrl\": [\n" + //
+                        "      \"ldap://ldap.local\"\n" + //
+                        "    ],\n" + //
+                        "    \"bindDn\": [\n" + //
+                        "      \"cn=admin,dc=ldap,dc=local\"\n" + //
+                        "    ],\n" + //
+                        "    \"bindCredential\": [\n" + //
+                        "      \"password\"\n" + //
+                        "    ],\n" + //
+                        "    \"startTls\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"authType\": [\n" + //
+                        "      \"simple\"\n" + //
+                        "    ],\n" + //
+                        "    \"usersDn\": [\n" + //
+                        "      \"ou=people,dc=ldap,dc=local\"\n" + //
+                        "    ],\n" + //
+                        "    \"usernameLDAPAttribute\": [\n" + //
+                        "      \"cn\"\n" + //
+                        "    ],\n" + //
+                        "    \"rdnLDAPAttribute\": [\n" + //
+                        "      \"uid\"\n" + //
+                        "    ],\n" + //
+                        "    \"uuidLDAPAttribute\": [\n" + //
+                        "      \"entryUUID\"\n" + //
+                        "    ],\n" + //
+                        "    \"userObjectClasses\": [\n" + //
+                        "      \"person\"\n" + //
+                        "    ],\n" + //
+                        "    \"customUserSearchFilter\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"searchScope\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"allowKerberosAuthentication\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"connectionTimeout\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"useTruststoreSpi\": [\n" + //
+                        "      \"always\"\n" + //
+                        "    ],\n" + //
+                        "    \"connectionPooling\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"readTimeout\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"editMode\": [\n" + //
+                        "      \"UNSYNCED\"\n" + //
+                        "    ],\n" + //
+                        "    \"batchSizeForSync\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"importEnabled\": [\n" + //
+                        "      \"true\"\n" + //
+                        "    ],\n" + //
+                        "    \"syncRegistrations\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"useKerberosForPasswordAuthentication\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"cachePolicy\": [\n" + //
+                        "      \"DEFAULT\"\n" + //
+                        "    ],\n" + //
+                        "    \"usePasswordModifyExtendedOp\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"validatePasswordPolicy\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"trustEmail\": [\n" + //
+                        "      \"true\"\n" + //
+                        "    ],\n" + //
+                        "    \"changedSyncPeriod\": [\n" + //
+                        "      \"-1\"\n" + //
+                        "    ],\n" + //
+                        "    \"fullSyncPeriod\": [\n" + //
+                        "      \"-1\"\n" + //
+                        "    ],\n" + //
+                        "    \"pagination\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ]\n" + //
+                        "  },\n" + //
+                        "  \"providerId\": \"ldap\",\n" + //
+                        "  \"providerType\": \"org.keycloak.storage.UserStorageProvider\",\n" + //
+                        "  \"parentId\": \"" + masterRealmId + "\",\n" + //
+                        "  \"name\": \"ldap\"\n" + //
+                        "}").getBytes());
+        conn.getOutputStream().close();
+        String location = conn.getHeaderField("Location");
+        conn.getInputStream().close();
+        String providerID = location.substring(location.lastIndexOf('/') + 1);
+
+        url = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/components");
+        conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        conn.getOutputStream().write(
+                ("{\n" + //
+                        "  \"name\": \"groups\",\n" + //
+                        "  \"parentId\": \"" + providerID + "\",\n" + //
+                        "  \"providerType\": \"org.keycloak.storage.ldap.mappers.LDAPStorageMapper\",\n" + //
+                        "  \"providerId\": \"group-with-link-ldap-mapper\",\n" + //
+                        "  \"config\": {\n" + //
+                        "    \"groups.dn\": [\n" + //
+                        "      \"ou=groups,dc=ldap,dc=local\"\n" + //
+                        "    ],\n" + //
+                        "    \"group.name.ldap.attribute\": [\n" + //
+                        "      \"cn\"\n" + //
+                        "    ],\n" + //
+                        "    \"group.object.classes\": [\n" + //
+                        "      \"groupOfNames\"\n" + //
+                        "    ],\n" + //
+                        "    \"preserve.group.inheritance\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"ignore.missing.groups\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"membership.ldap.attribute\": [\n" + //
+                        "      \"member\"\n" + //
+                        "    ],\n" + //
+                        "    \"membership.attribute.type\": [\n" + //
+                        "      \"DN\"\n" + //
+                        "    ],\n" + //
+                        "    \"membership.user.ldap.attribute\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"groups.ldap.filter\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"mode\": [\n" + //
+                        "      \"READ_ONLY\"\n" + //
+                        "    ],\n" + //
+                        "    \"user.roles.retrieve.strategy\": [\n" + //
+                        "      \"LOAD_GROUPS_BY_MEMBER_ATTRIBUTE\"\n" + //
+                        "    ],\n" + //
+                        "    \"memberof.ldap.attribute\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"mapped.group.attributes\": [\n" + //
+                        "      \"\"\n" + //
+                        "    ],\n" + //
+                        "    \"drop.non.existing.groups.during.sync\": [\n" + //
+                        "      \"false\"\n" + //
+                        "    ],\n" + //
+                        "    \"groups.path\": [\n" + //
+                        "      \"/\"\n" + //
+                        "    ]\n" + //
+                        "  }\n" + //
+                        "}").getBytes());
+        conn.getOutputStream().close();
+        location = conn.getHeaderField("Location");
+        conn.getInputStream().close();
+        String mapperID = location.substring(location.lastIndexOf('/') + 1);
+
+        return new ProviderAndMapper(providerID, mapperID);
+    }
+
+    private void syncLdapGroups(KeycloakContainer keycloak, ProviderAndMapper providerAndMapper) throws IOException {
+        URL url = new URL(
+                keycloak.getAuthServerUrl() + "/admin/realms/master/user-storage/" + providerAndMapper.providerID()
+                        + "/mappers/" + providerAndMapper.mapperID() + "/sync?direction=fedToKeycloak");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        conn.getOutputStream().write("{}".getBytes());
+
+        int responseCode = conn.getResponseCode();
+
+        if (responseCode != 200) {
+            System.out.println("Sync responseCode = " + responseCode);
+            InputStream errorStream = conn.getErrorStream();
+            if (errorStream != null) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = errorStream.read(buffer)) != -1) {
+                    System.out.write(buffer, 0, bytesRead);
+                }
+            }
+        }
+    }
+
+    private Stream<GroupWithLinkRepresentation> getGroupsWithLink(KeycloakContainer keycloak, String federationLink,
+            String search)
+            throws IOException {
+        URL url = new URL(
+                keycloak.getAuthServerUrl() + "/admin/realms/master/groups-with-link?link=" + federationLink
+                        + "&search=" + search);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+
+        int responseCode = conn.getResponseCode();
+
+        if (responseCode != 200) {
+            System.out.println("responseCode = " + responseCode);
+            InputStream errorStream = conn.getErrorStream();
+            if (errorStream != null) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = errorStream.read(buffer)) != -1) {
+                    System.out.write(buffer, 0, bytesRead);
+                }
+            }
+        }
+
+        String responsePayload = IOUtils.toString(conn.getInputStream(), "UTF-8");
+        // parse responsePayload JSON to Stream<GroupWithLinkRepresentation>
+        ObjectMapper objectMapper = new ObjectMapper();
+        GroupWithLinkRepresentation[] groupWithLinkRepresentations = objectMapper.readValue(responsePayload,
+                GroupWithLinkRepresentation[].class);
+        return Stream.of(groupWithLinkRepresentations);
+
+    }
+
+    @Test
+    public void groups_with_links_should_be_returned_when_listing_groups()
+            throws IOException, UnsupportedOperationException, InterruptedException {
+        Network network = Network.newNetwork();
+        // S
+        try (GenericContainer openldap = new GenericContainer<>("osixia/openldap:latest")
+                .withCreateContainerCmdModifier(it -> it.withHostName("ldap.local"))
+                .withNetwork(network)
+                .withEnv("LDAP_DOMAIN", "ldap.local")
+                .withEnv("LDAP_ADMIN_PASSWORD", "password")
+                .withEnv("LDAP_TLS_VERIFY_CLIENT", "try")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("/sample.ldif"), "/sample.ldif")
+                .withExposedPorts(389, 636)) {
+            openldap.start();
+
+            // Create some LDAP groups
+            openldap.execInContainer("ldapmodify", "-x", "-D",
+                    "cn=admin,dc=ldap,dc=local", "-w", "password", "-H",
+                    "ldap://ldap.local", "-f", "/sample.ldif");
+
+            try (KeycloakContainer keycloak = FullImageName.createContainer()
+                    .withNetwork(network)
+                    .withEnv("KC_LOG_LEVEL", "DEBUG")
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    .withLogConsumer(new Slf4jLogConsumer(logger))
+                    .withProviderClassesFrom("target/classes")) {
+                keycloak.start();
+
+                ProviderAndMapper providerAndMapper = createLdapConfigurationAndLdapGroupMapper(keycloak);
+                syncLdapGroups(keycloak, providerAndMapper);
+
+                // V
+                Stream<GroupWithLinkRepresentation> groupsWithLink = getGroupsWithLink(keycloak, "", "");
+
+                assertEquals(providerAndMapper.providerID(), groupsWithLink.findFirst().get().getFederationLink());
+
+                // E
+                // Create a local group
+                URL urlLocalGroup = new URL(
+                        keycloak.getAuthServerUrl() + "/admin/realms/master/groups");
+                HttpURLConnection connLocalGroup = (HttpURLConnection) urlLocalGroup.openConnection();
+                connLocalGroup.setRequestMethod("POST");
+                connLocalGroup.setRequestProperty("Authorization", "Bearer " + getToken(keycloak));
+                connLocalGroup.setRequestProperty("Content-Type", "application/json");
+                connLocalGroup.setDoOutput(true);
+                connLocalGroup.getOutputStream().write(
+                        ("{\n" + //
+                                "  \"name\": \"local-group\"\n" + //
+                                "}").getBytes());
+                connLocalGroup.getOutputStream().close();
+                connLocalGroup.getResponseCode();
+
+                // V
+                groupsWithLink = getGroupsWithLink(keycloak, "", "");
+                System.out.println(groupsWithLink);
+                assertEquals(2, groupsWithLink.count());
+
+                groupsWithLink = getGroupsWithLink(keycloak, providerAndMapper.providerID(), "");
+                System.out.println(groupsWithLink);
+                assertEquals(1, groupsWithLink.count());
+
+                groupsWithLink = getGroupsWithLink(keycloak, providerAndMapper.providerID(), "myGroup1");
+                System.out.println(groupsWithLink);
+                assertEquals(0, groupsWithLink.count());
+            }
+        }
+
+    }
+
+}

--- a/src/test/resources/sample.ldif
+++ b/src/test/resources/sample.ldif
@@ -1,0 +1,21 @@
+dn: ou=groups,dc=ldap,dc=local
+changetype: add
+objectClass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=ldap,dc=local
+changetype: add
+objectClass: organizationalUnit
+ou: people
+
+dn: cn=myGroup,ou=groups,dc=ldap,dc=local
+changetype: add
+objectClass: groupOfNames
+cn: myGroup
+member: cn=myPerson,ou=people,dc=ldap,dc=local
+
+dn: cn=myPerson,ou=people,dc=ldap,dc=local
+changetype: add
+objectClass: person
+cn: myPerson
+sn: LastName


### PR DESCRIPTION
This PR adds support for a ```federationLink``` in the Groups, so that when retrieving the groups via the group-with-links new endpoints we know if it is a LDAP federated group or not.

It introduces 2 major things: 
 - A new LDAP group mapper provider ID that needs to be used to keep the reference of the Provider Id next to the group (so when creating the group mapper we need to mention ```providerId: group-with-link-ldap-mapper ``` instead of. ```providerId: group-ldap-mapper```)
 - A new admin resource ```GET /admin/realms/master/groups-with-link``` that list groups apart with their federationLink if any is defined. The resource is searchable (thanks to the ```search``` query parameter and filterable per ```link``` to which we can provide the component id corresponding to the ldap integration component