### PR TITLE
(KC26) Use Dedicated SQL Session for Truststore

### DIFF
--- a/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
+++ b/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
@@ -48,7 +48,6 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
     private static final AtomicReference<CertificateRepresentation[]> cachedAllCertificates = new AtomicReference<>(null);
     private static final ConcurrentHashMap<Boolean, AtomicReference<CertificateRepresentation[]>> cachedFilteredCertificates = new ConcurrentHashMap<>();
     private static final AtomicLong cacheTimestamp = new AtomicLong(0);
-    private static final long CACHE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
     public JpaCertificateTruststoreProvider(KeycloakSession session) {
         this.session = session;
@@ -147,8 +146,7 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
      * Checks if the cache is still valid (not too old).
      */
     private boolean isCacheValid() {
-        long age = System.currentTimeMillis() - cacheTimestamp.get();
-        return age < CACHE_MAX_AGE_MS && cachedAllCertificates.get() != null;
+        return cachedAllCertificates.get() != null;
     }
 
     @Override

--- a/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
+++ b/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
@@ -10,8 +10,12 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -39,6 +43,12 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
 
     private final KeycloakSession session;
     protected static final Logger logger = Logger.getLogger(JpaCertificateTruststoreProvider.class);
+
+    // Cache for certificates to fallback when database is unavailable
+    private static final AtomicReference<CertificateRepresentation[]> cachedAllCertificates = new AtomicReference<>(null);
+    private static final ConcurrentHashMap<Boolean, AtomicReference<CertificateRepresentation[]>> cachedFilteredCertificates = new ConcurrentHashMap<>();
+    private static final AtomicLong cacheTimestamp = new AtomicLong(0);
+    private static final long CACHE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
     public JpaCertificateTruststoreProvider(KeycloakSession session) {
         this.session = session;
@@ -100,6 +110,45 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         
         // Recursively check cause
         return isConnectionClosedError(e.getCause());
+    }
+
+    /**
+     * Updates the cache with the provided certificates.
+     */
+    private void updateCache(CertificateRepresentation[] certificates) {
+        if (certificates != null) {
+            cachedAllCertificates.set(certificates);
+            cacheTimestamp.set(System.currentTimeMillis());
+            logger.debugf("Updated certificate cache with %d certificates", certificates.length);
+        }
+    }
+
+    /**
+     * Updates the cache for filtered certificates (by isRootCA).
+     */
+    private void updateFilteredCache(boolean isRootCA, CertificateRepresentation[] certificates) {
+        if (certificates != null) {
+            cachedFilteredCertificates.computeIfAbsent(isRootCA, k -> new AtomicReference<>()).set(certificates);
+            logger.debugf("Updated filtered certificate cache (isRootCA=%s) with %d certificates", isRootCA, certificates.length);
+        }
+    }
+
+    /**
+     * Invalidates the cache. Should be called when certificates are added, updated, or removed.
+     */
+    private void invalidateCache() {
+        cachedAllCertificates.set(null);
+        cachedFilteredCertificates.clear();
+        cacheTimestamp.set(0);
+        logger.debug("Invalidated certificate cache");
+    }
+
+    /**
+     * Checks if the cache is still valid (not too old).
+     */
+    private boolean isCacheValid() {
+        long age = System.currentTimeMillis() - cacheTimestamp.get();
+        return age < CACHE_MAX_AGE_MS && cachedAllCertificates.get() != null;
     }
 
     @Override
@@ -230,6 +279,9 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().flush();
         getEntityManager().clear();
 
+        // Invalidate cache since we added a new certificate
+        invalidateCache();
+
         return toCertificateRepresentation(entity);
     }
 
@@ -250,6 +302,9 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().flush();
         getEntityManager().clear();
 
+        // Invalidate cache since we updated a certificate
+        invalidateCache();
+
         return toCertificateRepresentation(entity);
     }
 
@@ -262,12 +317,15 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().remove(entity);
         getEntityManager().flush();
         getEntityManager().clear();
+
+        // Invalidate cache since we removed a certificate
+        invalidateCache();
     }
 
     @Override
     public CertificateRepresentation[] getCertificates() {
         try {
-            return Retry.call((iteration) -> {
+            CertificateRepresentation[] result = Retry.call((iteration) -> {
                 EntityManager em = getEntityManager();
                 FlushModeType originalFlushMode = em.getFlushMode();
                 try {
@@ -282,9 +340,12 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
                             .setHint(AvailableHints.HINT_CACHEABLE, false)
                             .setHint(AvailableHints.HINT_CACHE_MODE, CacheMode.IGNORE)
                             .getResultList();
-                    return list.stream()
+                    CertificateRepresentation[] certificates = list.stream()
                             .map(this::toCertificateRepresentation)
                             .toArray(CertificateRepresentation[]::new);
+                    // Update cache on successful retrieval
+                    updateCache(certificates);
+                    return certificates;
                 } catch (RuntimeException e) {
                     // Retry on connection closed errors or flush during cascade errors
                     if (isConnectionClosedError(e) && iteration < 2) {
@@ -299,16 +360,30 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
                     em.setFlushMode(originalFlushMode);
                 }
             }, 3, 50); // 3 attempts with 50ms delay
+            return result;
         } catch (Exception e) {
-            logger.error("Failed to get certificates after retries", e);
-            throw new RuntimeException("Failed to get certificates", e);
+            logger.error("Failed to get certificates after retries, attempting cache fallback", e);
+            // Fallback to cache if available and valid
+            CertificateRepresentation[] cached = cachedAllCertificates.get();
+            if (cached != null && isCacheValid()) {
+                logger.warnf("Using cached certificates (count: %d) due to database failure. Cache age: %d ms", 
+                    cached.length, System.currentTimeMillis() - cacheTimestamp.get());
+                return cached;
+            } else if (cached != null) {
+                logger.warnf("Cache exists but is expired (age: %d ms). Using expired cache as last resort.", 
+                    System.currentTimeMillis() - cacheTimestamp.get());
+                return cached;
+            } else {
+                logger.error("No cached certificates available, cannot fallback");
+                throw new RuntimeException("Failed to get certificates and no cache available", e);
+            }
         }
     }
 
     @Override
     public CertificateRepresentation[] getCertificates(boolean isRootCA) {
         try {
-            return Retry.call((iteration) -> {
+            CertificateRepresentation[] result = Retry.call((iteration) -> {
                 EntityManager em = getEntityManager();
                 FlushModeType originalFlushMode = em.getFlushMode();
                 try {
@@ -316,13 +391,16 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
                     // This avoids "Flush during cascade is dangerous" errors when there are pending
                     // changes from other entities in the same EntityManager session.
                     em.setFlushMode(FlushModeType.COMMIT);
-                    return em
+                    CertificateRepresentation[] certificates = em
                             .createNamedQuery("findByIsRootCA", TruststoreEntity.class)
                             .setParameter("isRootCA", isRootCA)
                             .getResultList()
                             .stream()
                             .map(this::toCertificateRepresentation)
                             .toArray(CertificateRepresentation[]::new);
+                    // Update filtered cache on successful retrieval
+                    updateFilteredCache(isRootCA, certificates);
+                    return certificates;
                 } catch (RuntimeException e) {
                     // Retry on connection closed errors or flush during cascade errors
                     if (isConnectionClosedError(e) && iteration < 2) {
@@ -337,9 +415,52 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
                     em.setFlushMode(originalFlushMode);
                 }
             }, 3, 50); // 3 attempts with 50ms delay
+            return result;
         } catch (Exception e) {
-            logger.errorf("Failed to get certificates (isRootCA=%s) after retries", isRootCA, e);
-            throw new RuntimeException("Failed to get certificates", e);
+            logger.errorf("Failed to get certificates (isRootCA=%s) after retries, attempting cache fallback", isRootCA, e);
+            // First try filtered cache
+            AtomicReference<CertificateRepresentation[]> filteredCache = cachedFilteredCertificates.get(isRootCA);
+            if (filteredCache != null && filteredCache.get() != null) {
+                logger.warnf("Using cached filtered certificates (isRootCA=%s, count: %d) due to database failure", 
+                    isRootCA, filteredCache.get().length);
+                return filteredCache.get();
+            }
+            // Fallback to full cache and filter it
+            CertificateRepresentation[] cached = cachedAllCertificates.get();
+            if (cached != null && isCacheValid()) {
+                logger.warnf("Using cached certificates and filtering (isRootCA=%s) due to database failure. Cache age: %d ms", 
+                    isRootCA, System.currentTimeMillis() - cacheTimestamp.get());
+                // Filter the cached certificates
+                return Arrays.stream(cached)
+                    .filter(cert -> {
+                        try {
+                            X509Certificate x509Cert = toX509Certificate(cert.certificate());
+                            return isSelfSigned(x509Cert) == isRootCA;
+                        } catch (Exception ex) {
+                            logger.warnf("Error filtering cached certificate %s: %s", cert.alias(), ex.getMessage());
+                            return false;
+                        }
+                    })
+                    .toArray(CertificateRepresentation[]::new);
+            } else if (cached != null) {
+                logger.warnf("Cache exists but is expired (age: %d ms). Using expired cache as last resort.", 
+                    System.currentTimeMillis() - cacheTimestamp.get());
+                // Filter the expired cached certificates
+                return Arrays.stream(cached)
+                    .filter(cert -> {
+                        try {
+                            X509Certificate x509Cert = toX509Certificate(cert.certificate());
+                            return isSelfSigned(x509Cert) == isRootCA;
+                        } catch (Exception ex) {
+                            logger.warnf("Error filtering cached certificate %s: %s", cert.alias(), ex.getMessage());
+                            return false;
+                        }
+                    })
+                    .toArray(CertificateRepresentation[]::new);
+            } else {
+                logger.errorf("No cached certificates available for isRootCA=%s, cannot fallback", isRootCA);
+                throw new RuntimeException("Failed to get certificates and no cache available", e);
+            }
         }
     }
 

--- a/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
+++ b/src/main/java/com/scality/keycloak/truststore/JpaCertificateTruststoreProvider.java
@@ -10,12 +10,10 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -23,130 +21,46 @@ import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x500.style.IETFUtils;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.hibernate.CacheMode;
-import org.hibernate.exception.GenericJDBCException;
 import org.hibernate.jpa.AvailableHints;
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Retry;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.ErrorResponse;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.FlushModeType;
 import jakarta.persistence.NoResultException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response.Status;
-import java.sql.SQLException;
 
 public class JpaCertificateTruststoreProvider implements CertificateTruststoreProvider {
 
     private final KeycloakSession session;
     protected static final Logger logger = Logger.getLogger(JpaCertificateTruststoreProvider.class);
 
-    // Cache for certificates to fallback when database is unavailable
-    private static final AtomicReference<CertificateRepresentation[]> cachedAllCertificates = new AtomicReference<>(null);
-    private static final ConcurrentHashMap<Boolean, AtomicReference<CertificateRepresentation[]>> cachedFilteredCertificates = new ConcurrentHashMap<>();
-    private static final AtomicLong cacheTimestamp = new AtomicLong(0);
-
     public JpaCertificateTruststoreProvider(KeycloakSession session) {
         this.session = session;
     }
 
-    /***
-     * 
-     * @return EntityManager
-     */
     private EntityManager getEntityManager() {
         return session.getProvider(JpaConnectionProvider.class).getEntityManager();
     }
 
     /**
-     * Checks if the exception is related to a closed connection or statement.
-     * These errors can occur when the connection pool closes connections due to timeouts
-     * or when transactions are committed/rolled back prematurely.
-     * Also checks for Hibernate flush errors that can occur during cascade operations.
+     * Executes a database query in a completely new Keycloak session with a fresh JDBC connection.
+     * Used on retry when the current session's connection is closed — em.clear() on the same
+     * EntityManager does NOT get a new connection, so we must open a new session entirely.
      */
-    private boolean isConnectionClosedError(Throwable e) {
-        if (e == null) {
-            return false;
-        }
-        
-        String message = e.getMessage();
-        if (message != null) {
-            String lowerMessage = message.toLowerCase();
-            if (lowerMessage.contains("connection is closed") ||
-                lowerMessage.contains("this statement has been closed") ||
-                lowerMessage.contains("statement has been closed") ||
-                lowerMessage.contains("connection closed") ||
-                lowerMessage.contains("flush during cascade")) {
-                return true;
+    private <T> T executeInNewSession(Function<EntityManager, T> query) {
+        AtomicReference<T> resultRef = new AtomicReference<>();
+        KeycloakModelUtils.runJobInTransaction(
+            session.getKeycloakSessionFactory(),
+            newSession -> {
+                EntityManager newEm = newSession.getProvider(JpaConnectionProvider.class).getEntityManager();
+                resultRef.set(query.apply(newEm));
             }
-        }
-        
-        // Check for HibernateException related to flush during cascade
-        if (e instanceof org.hibernate.HibernateException) {
-            String hibernateMessage = e.getMessage();
-            if (hibernateMessage != null && hibernateMessage.contains("Flush during cascade")) {
-                return true;
-            }
-        }
-        
-        // Check for SQLException with specific SQL states
-        if (e instanceof SQLException) {
-            SQLException sqlEx = (SQLException) e;
-            String sqlState = sqlEx.getSQLState();
-            // SQLState 55000 is a generic PostgreSQL error that can indicate connection issues
-            if ("55000".equals(sqlState) || sqlState == null) {
-                return true;
-            }
-        }
-        
-        // Check for GenericJDBCException which wraps SQL exceptions
-        if (e instanceof GenericJDBCException) {
-            return isConnectionClosedError(e.getCause());
-        }
-        
-        // Recursively check cause
-        return isConnectionClosedError(e.getCause());
-    }
-
-    /**
-     * Updates the cache with the provided certificates.
-     */
-    private void updateCache(CertificateRepresentation[] certificates) {
-        if (certificates != null) {
-            cachedAllCertificates.set(certificates);
-            cacheTimestamp.set(System.currentTimeMillis());
-            logger.debugf("Updated certificate cache with %d certificates", certificates.length);
-        }
-    }
-
-    /**
-     * Updates the cache for filtered certificates (by isRootCA).
-     */
-    private void updateFilteredCache(boolean isRootCA, CertificateRepresentation[] certificates) {
-        if (certificates != null) {
-            cachedFilteredCertificates.computeIfAbsent(isRootCA, k -> new AtomicReference<>()).set(certificates);
-            logger.debugf("Updated filtered certificate cache (isRootCA=%s) with %d certificates", isRootCA, certificates.length);
-        }
-    }
-
-    /**
-     * Invalidates the cache. Should be called when certificates are added, updated, or removed.
-     */
-    private void invalidateCache() {
-        cachedAllCertificates.set(null);
-        cachedFilteredCertificates.clear();
-        cacheTimestamp.set(0);
-        logger.debug("Invalidated certificate cache");
-    }
-
-    /**
-     * Checks if the cache is still valid (not too old).
-     */
-    private boolean isCacheValid() {
-        return cachedAllCertificates.get() != null;
+        );
+        return resultRef.get();
     }
 
     @Override
@@ -182,41 +96,13 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
     @Override
     public CertificateRepresentation getCertificate(String alias) {
         try {
-            return Retry.call((iteration) -> {
-                EntityManager em = getEntityManager();
-                FlushModeType originalFlushMode = em.getFlushMode();
-                try {
-                    // Set flush mode to COMMIT to prevent automatic flushing during query execution.
-                    // This avoids "Flush during cascade is dangerous" errors when there are pending
-                    // changes from other entities in the same EntityManager session.
-                    em.setFlushMode(FlushModeType.COMMIT);
-                    TruststoreEntity certificate = em
-                            .createNamedQuery("findByAlias", TruststoreEntity.class)
-                            .setParameter("alias", alias)
-                            .getSingleResult();
-                    return toCertificateRepresentation(certificate);
-                } catch (NoResultException e) {
-                    throw new NotFoundException("Certificate not found");
-                } catch (RuntimeException e) {
-                    // Retry on connection closed errors or flush during cascade errors
-                    if (isConnectionClosedError(e) && iteration < 2) {
-                        logger.debugf("Connection or flush error on getCertificate, retrying (iteration %d)", iteration);
-                        em.clear();
-                        throw e;
-                    }
-                    throw e;
-                } finally {
-                    // Restore the original flush mode
-                    em.setFlushMode(originalFlushMode);
-                }
-            }, 3, 50); // 3 attempts with 50ms delay
-        } catch (NotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            if (e.getCause() instanceof NotFoundException) {
-                throw (NotFoundException) e.getCause();
-            }
-            throw new RuntimeException("Failed to get certificate: " + alias, e);
+            TruststoreEntity certificate = getEntityManager()
+                    .createNamedQuery("findByAlias", TruststoreEntity.class)
+                    .setParameter("alias", alias)
+                    .getSingleResult();
+            return toCertificateRepresentation(certificate);
+        } catch (NoResultException e) {
+            throw new NotFoundException("Certificate not found");
         }
     }
 
@@ -277,9 +163,6 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().flush();
         getEntityManager().clear();
 
-        // Invalidate cache since we added a new certificate
-        invalidateCache();
-
         return toCertificateRepresentation(entity);
     }
 
@@ -300,9 +183,6 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().flush();
         getEntityManager().clear();
 
-        // Invalidate cache since we updated a certificate
-        invalidateCache();
-
         return toCertificateRepresentation(entity);
     }
 
@@ -315,151 +195,33 @@ public class JpaCertificateTruststoreProvider implements CertificateTruststorePr
         getEntityManager().remove(entity);
         getEntityManager().flush();
         getEntityManager().clear();
-
-        // Invalidate cache since we removed a certificate
-        invalidateCache();
     }
 
     @Override
     public CertificateRepresentation[] getCertificates() {
-        try {
-            CertificateRepresentation[] result = Retry.call((iteration) -> {
-                EntityManager em = getEntityManager();
-                FlushModeType originalFlushMode = em.getFlushMode();
-                try {
-                    // Set flush mode to COMMIT to prevent automatic flushing during query execution.
-                    // This avoids "Flush during cascade is dangerous" errors when there are pending
-                    // changes from other entities in the same EntityManager session.
-                    em.setFlushMode(FlushModeType.COMMIT);
-                    @SuppressWarnings("unchecked")
-                    List<TruststoreEntity> list = (List<TruststoreEntity>) em
-                            .createNativeQuery("select t.id, t.alias, t.certificate, t.is_root_ca from truststore t",
-                                    TruststoreEntity.class)
-                            .setHint(AvailableHints.HINT_CACHEABLE, false)
-                            .setHint(AvailableHints.HINT_CACHE_MODE, CacheMode.IGNORE)
-                            .getResultList();
-                    CertificateRepresentation[] certificates = list.stream()
-                            .map(this::toCertificateRepresentation)
-                            .toArray(CertificateRepresentation[]::new);
-                    // Update cache on successful retrieval
-                    updateCache(certificates);
-                    return certificates;
-                } catch (RuntimeException e) {
-                    // Retry on connection closed errors or flush during cascade errors
-                    if (isConnectionClosedError(e) && iteration < 2) {
-                        logger.debugf("Connection or flush error on getCertificates, retrying (iteration %d)", iteration);
-                        // Clear the entity manager to force a new connection on retry
-                        em.clear();
-                        throw e;
-                    }
-                    throw e;
-                } finally {
-                    // Restore the original flush mode
-                    em.setFlushMode(originalFlushMode);
-                }
-            }, 3, 50); // 3 attempts with 50ms delay
-            return result;
-        } catch (Exception e) {
-            logger.error("Failed to get certificates after retries, attempting cache fallback", e);
-            // Fallback to cache if available and valid
-            CertificateRepresentation[] cached = cachedAllCertificates.get();
-            if (cached != null && isCacheValid()) {
-                logger.warnf("Using cached certificates (count: %d) due to database failure. Cache age: %d ms", 
-                    cached.length, System.currentTimeMillis() - cacheTimestamp.get());
-                return cached;
-            } else if (cached != null) {
-                logger.warnf("Cache exists but is expired (age: %d ms). Using expired cache as last resort.", 
-                    System.currentTimeMillis() - cacheTimestamp.get());
-                return cached;
-            } else {
-                logger.error("No cached certificates available, cannot fallback");
-                throw new RuntimeException("Failed to get certificates and no cache available", e);
-            }
-        }
+        return executeInNewSession(newEm -> {
+            @SuppressWarnings("unchecked")
+            List<TruststoreEntity> list = (List<TruststoreEntity>) newEm
+                    .createNativeQuery("select t.id, t.alias, t.certificate, t.is_root_ca from truststore t",
+                            TruststoreEntity.class)
+                    .setHint(AvailableHints.HINT_CACHEABLE, false)
+                    .setHint(AvailableHints.HINT_CACHE_MODE, CacheMode.IGNORE)
+                    .getResultList();
+            return list.stream()
+                    .map(this::toCertificateRepresentation)
+                    .toArray(CertificateRepresentation[]::new);
+        });
     }
 
     @Override
     public CertificateRepresentation[] getCertificates(boolean isRootCA) {
-        try {
-            CertificateRepresentation[] result = Retry.call((iteration) -> {
-                EntityManager em = getEntityManager();
-                FlushModeType originalFlushMode = em.getFlushMode();
-                try {
-                    // Set flush mode to COMMIT to prevent automatic flushing during query execution.
-                    // This avoids "Flush during cascade is dangerous" errors when there are pending
-                    // changes from other entities in the same EntityManager session.
-                    em.setFlushMode(FlushModeType.COMMIT);
-                    CertificateRepresentation[] certificates = em
-                            .createNamedQuery("findByIsRootCA", TruststoreEntity.class)
-                            .setParameter("isRootCA", isRootCA)
-                            .getResultList()
-                            .stream()
-                            .map(this::toCertificateRepresentation)
-                            .toArray(CertificateRepresentation[]::new);
-                    // Update filtered cache on successful retrieval
-                    updateFilteredCache(isRootCA, certificates);
-                    return certificates;
-                } catch (RuntimeException e) {
-                    // Retry on connection closed errors or flush during cascade errors
-                    if (isConnectionClosedError(e) && iteration < 2) {
-                        logger.debugf("Connection or flush error on getCertificates(isRootCA=%s), retrying (iteration %d)", isRootCA, iteration);
-                        // Clear the entity manager to force a new connection on retry
-                        em.clear();
-                        throw e;
-                    }
-                    throw e;
-                } finally {
-                    // Restore the original flush mode
-                    em.setFlushMode(originalFlushMode);
-                }
-            }, 3, 50); // 3 attempts with 50ms delay
-            return result;
-        } catch (Exception e) {
-            logger.errorf("Failed to get certificates (isRootCA=%s) after retries, attempting cache fallback", isRootCA, e);
-            // First try filtered cache
-            AtomicReference<CertificateRepresentation[]> filteredCache = cachedFilteredCertificates.get(isRootCA);
-            if (filteredCache != null && filteredCache.get() != null) {
-                logger.warnf("Using cached filtered certificates (isRootCA=%s, count: %d) due to database failure", 
-                    isRootCA, filteredCache.get().length);
-                return filteredCache.get();
-            }
-            // Fallback to full cache and filter it
-            CertificateRepresentation[] cached = cachedAllCertificates.get();
-            if (cached != null && isCacheValid()) {
-                logger.warnf("Using cached certificates and filtering (isRootCA=%s) due to database failure. Cache age: %d ms", 
-                    isRootCA, System.currentTimeMillis() - cacheTimestamp.get());
-                // Filter the cached certificates
-                return Arrays.stream(cached)
-                    .filter(cert -> {
-                        try {
-                            X509Certificate x509Cert = toX509Certificate(cert.certificate());
-                            return isSelfSigned(x509Cert) == isRootCA;
-                        } catch (Exception ex) {
-                            logger.warnf("Error filtering cached certificate %s: %s", cert.alias(), ex.getMessage());
-                            return false;
-                        }
-                    })
-                    .toArray(CertificateRepresentation[]::new);
-            } else if (cached != null) {
-                logger.warnf("Cache exists but is expired (age: %d ms). Using expired cache as last resort.", 
-                    System.currentTimeMillis() - cacheTimestamp.get());
-                // Filter the expired cached certificates
-                return Arrays.stream(cached)
-                    .filter(cert -> {
-                        try {
-                            X509Certificate x509Cert = toX509Certificate(cert.certificate());
-                            return isSelfSigned(x509Cert) == isRootCA;
-                        } catch (Exception ex) {
-                            logger.warnf("Error filtering cached certificate %s: %s", cert.alias(), ex.getMessage());
-                            return false;
-                        }
-                    })
-                    .toArray(CertificateRepresentation[]::new);
-            } else {
-                logger.errorf("No cached certificates available for isRootCA=%s, cannot fallback", isRootCA);
-                throw new RuntimeException("Failed to get certificates and no cache available", e);
-            }
-        }
+        return executeInNewSession(newEm -> newEm
+                .createNamedQuery("findByIsRootCA", TruststoreEntity.class)
+                .setParameter("isRootCA", isRootCA)
+                .getResultList()
+                .stream()
+                .map(this::toCertificateRepresentation)
+                .toArray(CertificateRepresentation[]::new));
     }
 
     @Override


### PR DESCRIPTION
Context:
JDBC Connection gets closed under load after some time.

What Changed:
Replace retry/cache complexity with executeInNewSession for reads
getCertificates() and getCertificates(boolean) now always execute in a
fresh Keycloak session via KeycloakModelUtils.runJobInTransaction(),
obtaining a new JDBC connection from the pool. This replaces the
previous approach of em.clear() (which did not reset the connection),
manual retry loops, flush mode manipulation, and in-memory cache
fallback — none of which reliably handled the cold-start case where the
current session's connection is closed.

How was it validated
1000/1000, 0 failures on KC26. The executeInNewSession fix is validated on Keycloak 26.2.0.