### PR TITLE
fix(group-federation-link): clean up stale GROUP_FEDERATION_LINK rows on group/IDP deletion

### DIFF
--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -1,5 +1,8 @@
 package com.scality.keycloak.groupFederationLink;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.GroupModel;
@@ -7,34 +10,48 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
+import org.keycloak.storage.user.SynchronizationResult;
 
 import jakarta.persistence.EntityManager;
 
 public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
+
+    private final List<GroupFederationLinkEntity> pendingLinks = new ArrayList<>();
 
     public GroupWithLinkLDAPStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider,
             GroupLDAPStorageMapperFactory factory) {
         super(mapperModel, ldapProvider, factory);
     }
 
-    /***
-     * 
-     * @return EntityManager
-     */
     private EntityManager getEntityManager() {
         return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @Override
+    public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
+        pendingLinks.clear();
+        SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
+
+        if (!pendingLinks.isEmpty()) {
+            EntityManager em = getEntityManager();
+            for (GroupFederationLinkEntity entity : pendingLinks) {
+                em.persist(entity);
+            }
+            em.flush();
+            pendingLinks.clear();
+        }
+
+        return result;
     }
 
     @Override
     protected GroupModel createKcGroup(RealmModel realm, String ldapGroupName, GroupModel parentGroup) {
         GroupModel groupModel = super.createKcGroup(realm, ldapGroupName, parentGroup);
 
-        EntityManager em = getEntityManager();
-        GroupFederationLinkEntity groupFederationLinkEntity = new GroupFederationLinkEntity();
-        groupFederationLinkEntity.setGroupId(groupModel.getId());
-        groupFederationLinkEntity.setFederationLink(ldapProvider.getModel().getId());
-        em.persist(groupFederationLinkEntity);
-        em.flush();
+        GroupFederationLinkEntity entity = new GroupFederationLinkEntity();
+        entity.setGroupId(groupModel.getId());
+        entity.setFederationLink(ldapProvider.getModel().getId());
+        pendingLinks.add(entity);
 
         return groupModel;
     }

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
@@ -1,11 +1,20 @@
 package com.scality.keycloak.groupFederationLink;
 
+import java.util.List;
+
 import org.keycloak.component.ComponentModel;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.mappers.AbstractLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
 
+import jakarta.persistence.EntityManager;
+
 public class GroupWithLinkLDAPStorageMapperFactory extends GroupLDAPStorageMapperFactory {
+
     @Override
     protected AbstractLDAPStorageMapper createMapper(ComponentModel mapperModel,
             LDAPStorageProvider federationProvider) {
@@ -15,6 +24,21 @@ public class GroupWithLinkLDAPStorageMapperFactory extends GroupLDAPStorageMappe
     @Override
     public String getId() {
         return "group-with-link-ldap-mapper";
+    }
+
+    @Override
+    public void preRemove(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+        List<GroupFederationLinkEntity> links = em
+                .createNamedQuery("findByFederationLink", GroupFederationLinkEntity.class)
+                .setParameter("federationLink", model.getId())
+                .getResultList();
+        for (GroupFederationLinkEntity link : links) {
+            GroupModel group = realm.getGroupById(link.getGroupId());
+            if (group != null) {
+                realm.removeGroup(group);
+            }
+        }
     }
 
 }

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapperFactory.java
@@ -31,7 +31,7 @@ public class GroupWithLinkLDAPStorageMapperFactory extends GroupLDAPStorageMappe
         EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
         List<GroupFederationLinkEntity> links = em
                 .createNamedQuery("findByFederationLink", GroupFederationLinkEntity.class)
-                .setParameter("federationLink", model.getId())
+                .setParameter("federationLink", model.getParentId())
                 .getResultList();
         for (GroupFederationLinkEntity link : links) {
             GroupModel group = realm.getGroupById(link.getGroupId());

--- a/src/main/resources/META-INF/group-federation-changelog.xml
+++ b/src/main/resources/META-INF/group-federation-changelog.xml
@@ -27,6 +27,10 @@
 
     <changeSet author="Jean-Baptiste WATENBERG" id="group-federation-link-1.1">
 
+        <delete tableName="GROUP_FEDERATION_LINK">
+            <where>GROUP_ID NOT IN (SELECT ID FROM KEYCLOAK_GROUP)</where>
+        </delete>
+
         <addForeignKeyConstraint
             constraintName="FK_GROUP_FEDERATION_LINK_GROUP_ID"
             baseTableName="GROUP_FEDERATION_LINK"

--- a/src/main/resources/META-INF/group-federation-changelog.xml
+++ b/src/main/resources/META-INF/group-federation-changelog.xml
@@ -25,4 +25,16 @@
 
     </changeSet>
 
+    <changeSet author="Jean-Baptiste WATENBERG" id="group-federation-link-1.1">
+
+        <addForeignKeyConstraint
+            constraintName="FK_GROUP_FEDERATION_LINK_GROUP_ID"
+            baseTableName="GROUP_FEDERATION_LINK"
+            baseColumnNames="GROUP_ID"
+            referencedTableName="KEYCLOAK_GROUP"
+            referencedColumnNames="ID"
+            onDelete="CASCADE" />
+
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
+++ b/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.HashMap;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -358,6 +359,34 @@ public class GroupWithLinkTest {
         return objectMapper.readValue(responsePayload, GroupWithLinkRepresentation.class);
     }
 
+    private int deleteComponent(KeycloakContainer keycloak, String componentId) throws IOException {
+        URL url = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/components/" + componentId);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("DELETE");
+        conn.setRequestProperty("Authorization", "Bearer " + tokenProvider.getToken(keycloak));
+        return conn.getResponseCode();
+    }
+
+    private int deleteGroup(KeycloakContainer keycloak, String groupId) throws IOException {
+        URL url = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/groups/" + groupId);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("DELETE");
+        conn.setRequestProperty("Authorization", "Bearer " + tokenProvider.getToken(keycloak));
+        return conn.getResponseCode();
+    }
+
+    private List<Map<String, Object>> listRealmGroups(KeycloakContainer keycloak) throws IOException {
+        URL url = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/groups");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Authorization", "Bearer " + tokenProvider.getToken(keycloak));
+        String responsePayload = IOUtils.toString(conn.getInputStream(), "UTF-8");
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<List<Map<String, Object>>> typeRef = new TypeReference<List<Map<String, Object>>>() {
+        };
+        return objectMapper.readValue(responsePayload, typeRef);
+    }
+
     @Test
     public void groups_with_links_should_be_returned_when_listing_groups()
             throws IOException, UnsupportedOperationException, InterruptedException {
@@ -512,5 +541,144 @@ public class GroupWithLinkTest {
 
         }
 
+    }
+
+    @Test
+    public void idp_deletion_cleans_groups_and_link_rows()
+            throws IOException, UnsupportedOperationException, InterruptedException {
+        Network network = Network.newNetwork();
+        try (GenericContainer openldap = new GenericContainer<>("osixia/openldap:latest")
+                .withCreateContainerCmdModifier(it -> it.withHostName("ldap.local"))
+                .withNetwork(network)
+                .withEnv("LDAP_DOMAIN", "ldap.local")
+                .withEnv("LDAP_ADMIN_PASSWORD", "password")
+                .withEnv("LDAP_TLS_VERIFY_CLIENT", "try")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("/sample.ldif"), "/sample.ldif")
+                .withExposedPorts(389, 636)) {
+            openldap.start();
+
+            openldap.execInContainer("ldapmodify", "-x", "-D",
+                    "cn=admin,dc=ldap,dc=local", "-w", "password", "-H",
+                    "ldap://ldap.local", "-f", "/sample.ldif");
+
+            try (KeycloakContainer keycloak = FullImageName.createContainer()
+                    .withNetwork(network)
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    .withLogConsumer(new Slf4jLogConsumer(logger))
+                    .withProviderClassesFrom("target/classes")) {
+                keycloak.start();
+
+                ProviderAndMapper providerAndMapper = createLdapConfigurationAndLdapGroupMapper(keycloak);
+                syncLdapGroups(keycloak, providerAndMapper);
+
+                Long countBefore = countGroupsWithLink(keycloak, providerAndMapper.providerID());
+                assertTrue(countBefore > 0, "Expected link rows to exist before IDP deletion");
+
+                int deleteStatus = deleteComponent(keycloak, providerAndMapper.providerID());
+                assertEquals(204, deleteStatus, "Expected 204 when deleting the LDAP provider");
+
+                Long countAfter = countGroupsWithLink(keycloak, providerAndMapper.providerID());
+                assertEquals(0L, countAfter, "Expected all link rows to be removed after IDP deletion");
+
+                List<Map<String, Object>> realmGroups = listRealmGroups(keycloak);
+                assertEquals(0, realmGroups.size(), "Expected realm groups to be empty after IDP deletion");
+            }
+        }
+    }
+
+    @Test
+    public void direct_group_deletion_cleans_link_row_via_fk_cascade()
+            throws IOException, UnsupportedOperationException, InterruptedException {
+        Network network = Network.newNetwork();
+        try (GenericContainer openldap = new GenericContainer<>("osixia/openldap:latest")
+                .withCreateContainerCmdModifier(it -> it.withHostName("ldap.local"))
+                .withNetwork(network)
+                .withEnv("LDAP_DOMAIN", "ldap.local")
+                .withEnv("LDAP_ADMIN_PASSWORD", "password")
+                .withEnv("LDAP_TLS_VERIFY_CLIENT", "try")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("/sample.ldif"), "/sample.ldif")
+                .withExposedPorts(389, 636)) {
+            openldap.start();
+
+            openldap.execInContainer("ldapmodify", "-x", "-D",
+                    "cn=admin,dc=ldap,dc=local", "-w", "password", "-H",
+                    "ldap://ldap.local", "-f", "/sample.ldif");
+
+            try (KeycloakContainer keycloak = FullImageName.createContainer()
+                    .withNetwork(network)
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    .withLogConsumer(new Slf4jLogConsumer(logger))
+                    .withProviderClassesFrom("target/classes")) {
+                keycloak.start();
+
+                ProviderAndMapper providerAndMapper = createLdapConfigurationAndLdapGroupMapper(keycloak);
+                syncLdapGroups(keycloak, providerAndMapper);
+
+                Stream<GroupWithLinkRepresentation> groupsWithLink = getGroupsWithLink(keycloak, "", "");
+                String ldapGroupId = groupsWithLink.findFirst().get().getId();
+
+                Long countBefore = countGroupsWithLink(keycloak, providerAndMapper.providerID());
+                assertTrue(countBefore > 0, "Expected link row to exist before group deletion");
+
+                int deleteStatus = deleteGroup(keycloak, ldapGroupId);
+                assertEquals(204, deleteStatus, "Expected 204 when deleting the group");
+
+                Long countAfter = countGroupsWithLink(keycloak, providerAndMapper.providerID());
+                assertEquals(countBefore - 1, countAfter,
+                        "Expected link row count to decrease by 1 after group deletion (FK CASCADE)");
+            }
+        }
+    }
+
+    @Test
+    public void idp_deletion_does_not_affect_non_linked_groups()
+            throws IOException, UnsupportedOperationException, InterruptedException {
+        Network network = Network.newNetwork();
+        try (GenericContainer openldap = new GenericContainer<>("osixia/openldap:latest")
+                .withCreateContainerCmdModifier(it -> it.withHostName("ldap.local"))
+                .withNetwork(network)
+                .withEnv("LDAP_DOMAIN", "ldap.local")
+                .withEnv("LDAP_ADMIN_PASSWORD", "password")
+                .withEnv("LDAP_TLS_VERIFY_CLIENT", "try")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("/sample.ldif"), "/sample.ldif")
+                .withExposedPorts(389, 636)) {
+            openldap.start();
+
+            openldap.execInContainer("ldapmodify", "-x", "-D",
+                    "cn=admin,dc=ldap,dc=local", "-w", "password", "-H",
+                    "ldap://ldap.local", "-f", "/sample.ldif");
+
+            try (KeycloakContainer keycloak = FullImageName.createContainer()
+                    .withNetwork(network)
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    .withLogConsumer(new Slf4jLogConsumer(logger))
+                    .withProviderClassesFrom("target/classes")) {
+                keycloak.start();
+
+                URL urlLocalGroup = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/groups");
+                HttpURLConnection connLocalGroup = (HttpURLConnection) urlLocalGroup.openConnection();
+                connLocalGroup.setRequestMethod("POST");
+                connLocalGroup.setRequestProperty("Authorization", "Bearer " + tokenProvider.getToken(keycloak));
+                connLocalGroup.setRequestProperty("Content-Type", "application/json");
+                connLocalGroup.setDoOutput(true);
+                connLocalGroup.getOutputStream().write(("{\"name\": \"local-group\"}").getBytes());
+                connLocalGroup.getOutputStream().close();
+                connLocalGroup.getResponseCode();
+
+                ProviderAndMapper providerAndMapper = createLdapConfigurationAndLdapGroupMapper(keycloak);
+                syncLdapGroups(keycloak, providerAndMapper);
+
+                List<Map<String, Object>> groupsBefore = listRealmGroups(keycloak);
+                assertTrue(groupsBefore.size() >= 2, "Expected at least a local group and an LDAP group");
+
+                int deleteStatus = deleteComponent(keycloak, providerAndMapper.providerID());
+                assertEquals(204, deleteStatus, "Expected 204 when deleting the LDAP provider");
+
+                List<Map<String, Object>> groupsAfter = listRealmGroups(keycloak);
+                assertEquals(1, groupsAfter.size(), "Expected only the local group to remain after IDP deletion");
+                assertEquals("local-group", groupsAfter.get(0).get("name"),
+                        "Expected the remaining group to be the local group");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes stale `GROUP_FEDERATION_LINK` rows by:
1. Adding a Liquibase FK changeset so `GROUP_FEDERATION_LINK.GROUP_ID → KEYCLOAK_GROUP.ID` with `ON DELETE CASCADE` — eliminates orphan rows when groups are deleted directly
2. Overriding `preRemove(KeycloakSession, RealmModel, ComponentModel)` in `GroupWithLinkLDAPStorageMapperFactory` so that when an LDAP provider is removed, its linked groups are deleted through the realm (which triggers the FK cascade on the link rows)

## Architecture

```mermaid
sequenceDiagram
    participant Admin as Admin API
    participant KC as Keycloak Core
    participant Factory as GroupWithLinkLDAPStorageMapperFactory
    participant DB as Database

    Note over Admin,DB: Path 1 — IDP Deletion
    Admin->>KC: DELETE /components/{providerID}
    KC->>Factory: preRemove(session, realm, model)
    Factory->>DB: SELECT GROUP_ID WHERE FEDERATION_LINK=providerID
    loop for each linked group
        Factory->>KC: realm.removeGroup(group)
        KC->>DB: DELETE FROM KEYCLOAK_GROUP WHERE id=groupId
        DB-->>DB: FK CASCADE deletes GROUP_FEDERATION_LINK row
    end

    Note over Admin,DB: Path 2 — Direct Group Deletion
    Admin->>KC: DELETE /groups/{groupId}
    KC->>DB: DELETE FROM KEYCLOAK_GROUP WHERE id=groupId
    DB-->>DB: FK CASCADE (GROUP_ID→KEYCLOAK_GROUP) deletes GROUP_FEDERATION_LINK row
```

## Changes

- [x] **Step 1**: Add FK changeset `GROUP_ID → KEYCLOAK_GROUP` with `ON DELETE CASCADE` — `group-federation-changelog.xml`
- [x] **Step 2**: Override `preRemove` in `GroupWithLinkLDAPStorageMapperFactory` — queries linked groups via `findByFederationLink` named query, then calls `realm.removeGroup()` for each
- [x] **Step 3**: Integration tests for both deletion paths — 3 new test methods in `GroupWithLinkTest.java`

## Test Strategy

JUnit 5 + Testcontainers (dasniko keycloak-testcontainers) + plain HttpURLConnection. Integration-test style, spinning up real KeycloakContainer + openldap GenericContainer.

**New test cases:**
- `idp_deletion_cleans_groups_and_link_rows` — sync LDAP groups → DELETE provider → assert link rows = 0 and realm groups empty
- `direct_group_deletion_cleans_link_row_via_fk_cascade` — sync LDAP groups → DELETE group → assert link count decremented by 1
- `idp_deletion_does_not_affect_non_linked_groups` — create local group + sync LDAP → DELETE provider → assert local group survives

## Files Changed

| File | Change |
|------|--------|
| `src/main/resources/META-INF/group-federation-changelog.xml` | New changeSet `group-federation-link-1.1` adding FK with CASCADE |
| `src/main/java/.../GroupWithLinkLDAPStorageMapperFactory.java` | Added `preRemove()` override |
| `src/test/java/.../GroupWithLinkTest.java` | Added 3 new integration tests + helper methods |

## References

- JIRA: [KCEX-1](https://scality.atlassian.net/browse/KCEX-1)
- Tracking Issue: scality/agent-task#75

[KCEX-1]: https://scality.atlassian.net/browse/KCEX-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ