### PR TITLE
fix(group-federation-link): link pre-existing KC groups matched by name during sync

### DIFF
--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -1,13 +1,15 @@
 package com.scality.keycloak.groupFederationLink;
 
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
 import org.keycloak.storage.user.SynchronizationResult;
@@ -16,7 +18,7 @@ import jakarta.persistence.EntityManager;
 
 public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
 
-    private final List<GroupFederationLinkEntity> pendingLinks = new ArrayList<>();
+    private final Map<String, GroupFederationLinkEntity> pendingLinks = new LinkedHashMap<>();
 
     public GroupWithLinkLDAPStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider,
             GroupLDAPStorageMapperFactory factory) {
@@ -31,11 +33,14 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
     public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
         pendingLinks.clear();
         SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
+        stagePendingLinksForAllLDAPGroups(realm);
 
         if (!pendingLinks.isEmpty()) {
             EntityManager em = getEntityManager();
-            for (GroupFederationLinkEntity entity : pendingLinks) {
-                em.persist(entity);
+            for (GroupFederationLinkEntity entity : pendingLinks.values()) {
+                if (em.find(GroupFederationLinkEntity.class, entity.getGroupId()) == null) {
+                    em.persist(entity);
+                }
             }
             em.flush();
             pendingLinks.clear();
@@ -47,13 +52,33 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
     @Override
     protected GroupModel createKcGroup(RealmModel realm, String ldapGroupName, GroupModel parentGroup) {
         GroupModel groupModel = super.createKcGroup(realm, ldapGroupName, parentGroup);
-
-        GroupFederationLinkEntity entity = new GroupFederationLinkEntity();
-        entity.setGroupId(groupModel.getId());
-        entity.setFederationLink(ldapProvider.getModel().getId());
-        pendingLinks.add(entity);
-
+        stagePendingLink(groupModel);
         return groupModel;
+    }
+
+    // Parent's sync only calls createKcGroup for brand-new groups; existing KC groups
+    // that match by name go through a private update path we can't hook. Reconcile
+    // here so every LDAP group ends up with a federation link, whether created now
+    // or matched to a pre-existing local group.
+    private void stagePendingLinksForAllLDAPGroups(RealmModel realm) {
+        List<LDAPObject> ldapGroups = getAllLDAPGroups(false);
+        for (LDAPObject ldapGroup : ldapGroups) {
+            GroupModel kcGroup = findKcGroupByLDAPGroup(realm, null, ldapGroup);
+            if (kcGroup != null) {
+                stagePendingLink(kcGroup);
+            }
+        }
+    }
+
+    private void stagePendingLink(GroupModel groupModel) {
+        String groupId = groupModel.getId();
+        if (pendingLinks.containsKey(groupId)) {
+            return;
+        }
+        GroupFederationLinkEntity entity = new GroupFederationLinkEntity();
+        entity.setGroupId(groupId);
+        entity.setFederationLink(ldapProvider.getModel().getId());
+        pendingLinks.put(groupId, entity);
     }
 
 }

--- a/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
+++ b/src/test/java/com/scality/keycloak/GroupWithLinkTest.java
@@ -631,6 +631,65 @@ public class GroupWithLinkTest {
     }
 
     @Test
+    public void existing_kc_group_with_same_name_should_be_linked_on_sync()
+            throws IOException, UnsupportedOperationException, InterruptedException {
+        Network network = Network.newNetwork();
+        try (GenericContainer openldap = new GenericContainer<>("osixia/openldap:latest")
+                .withCreateContainerCmdModifier(it -> it.withHostName("ldap.local"))
+                .withNetwork(network)
+                .withEnv("LDAP_DOMAIN", "ldap.local")
+                .withEnv("LDAP_ADMIN_PASSWORD", "password")
+                .withEnv("LDAP_TLS_VERIFY_CLIENT", "try")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("/sample.ldif"), "/sample.ldif")
+                .withExposedPorts(389, 636)) {
+            openldap.start();
+
+            openldap.execInContainer("ldapmodify", "-x", "-D",
+                    "cn=admin,dc=ldap,dc=local", "-w", "password", "-H",
+                    "ldap://ldap.local", "-f", "/sample.ldif");
+
+            try (KeycloakContainer keycloak = FullImageName.createContainer()
+                    .withNetwork(network)
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    .withLogConsumer(new Slf4jLogConsumer(logger))
+                    .withProviderClassesFrom("target/classes")) {
+                keycloak.start();
+
+                // Pre-create a local realm group whose name matches an LDAP group. Sync
+                // must still produce a federation link row for it.
+                URL urlLocalGroup = new URL(keycloak.getAuthServerUrl() + "/admin/realms/master/groups");
+                HttpURLConnection connLocalGroup = (HttpURLConnection) urlLocalGroup.openConnection();
+                connLocalGroup.setRequestMethod("POST");
+                connLocalGroup.setRequestProperty("Authorization", "Bearer " + tokenProvider.getToken(keycloak));
+                connLocalGroup.setRequestProperty("Content-Type", "application/json");
+                connLocalGroup.setDoOutput(true);
+                connLocalGroup.getOutputStream().write(("{\"name\": \"myGroup\"}").getBytes());
+                connLocalGroup.getOutputStream().close();
+                assertEquals(201, connLocalGroup.getResponseCode(), "Expected 201 when creating the local group");
+
+                ProviderAndMapper providerAndMapper = createLdapConfigurationAndLdapGroupMapper(keycloak);
+                syncLdapGroups(keycloak, providerAndMapper);
+
+                Long linkedCount = countGroupsWithLink(keycloak, providerAndMapper.providerID());
+                assertEquals(1L, linkedCount,
+                        "Expected the pre-existing local group to be linked to the LDAP provider after sync");
+
+                Stream<GroupWithLinkRepresentation> linked = getGroupsWithLink(keycloak,
+                        providerAndMapper.providerID(), "");
+                GroupWithLinkRepresentation linkedGroup = linked.findFirst().get();
+                assertEquals("myGroup", linkedGroup.getName(),
+                        "Expected the linked group to be the pre-existing local group");
+                assertEquals(providerAndMapper.providerID(), linkedGroup.getFederationLink(),
+                        "Expected the pre-existing group's federationLink to point to the LDAP provider");
+
+                syncLdapGroups(keycloak, providerAndMapper);
+                assertEquals(1L, countGroupsWithLink(keycloak, providerAndMapper.providerID()),
+                        "Expected the link row count to stay at 1 after a second sync (idempotent)");
+            }
+        }
+    }
+
+    @Test
     public void idp_deletion_does_not_affect_non_linked_groups()
             throws IOException, UnsupportedOperationException, InterruptedException {
         Network network = Network.newNetwork();


### PR DESCRIPTION
**TL;DR** — On sync, LDAP groups whose names already exist as local Keycloak groups now also get their `GROUP_FEDERATION_LINK` row written; previously they were silently skipped, leaving identity-ui's Groups-to-Roles screen empty.

### Context / Why

RD-2013: on a fresh RING 9.5.3 install, adding a new LDAP identity provider succeeds and reports "N groups updated", but the subsequent Groups-to-Roles mapping step lists no groups — the operator can't finish the wizard. A fresh RING install ships with local realm groups (`RING_Admins`, `Artesca-*`, …) whose names collide with the customer's AD tree under `ou=groups,dc=…`; the extension only wrote link rows when Keycloak *created* a KC group during sync, so every LDAP group that matched a same-named local group was silently skipped.

### 🧩 Approach

Keycloak's parent `GroupLDAPStorageMapper.syncDataFromFederationProviderToKeycloak` matches LDAP groups against realm groups by name and routes matched groups through `updateAttributesOfKCGroup(GroupModel, LDAPObject)` — which is **private** in Keycloak 26.2.0 and can't be overridden. Reconciling from `createKcGroup` alone therefore misses the existing-name case by design.

The fix runs a reconciliation pass **after** `super.sync()` returns, using two `protected` helpers the parent exposes — `getAllLDAPGroups(false)` (loads the LDAP-side group list the sync just processed) and `findKcGroupByLDAPGroup(realm, null, ldapGroup)` (mirrors the same by-name lookup the parent uses internally). Anything with a matching KC group is staged into `pendingLinks`; the final persist step now upserts (skip if a row exists on the `GROUP_ID` PK), making the operation idempotent under retries.

Before:
```java
public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
    pendingLinks.clear();
    SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
    for (GroupFederationLinkEntity entity : pendingLinks) em.persist(entity);   // ← only entries from createKcGroup
    em.flush();
    return result;
}
```

After:
```java
public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
    pendingLinks.clear();
    SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
    stagePendingLinksForAllLDAPGroups(realm);                                                        // ← also stage matched-existing groups
    for (GroupFederationLinkEntity entity : pendingLinks.values()) {
        if (em.find(GroupFederationLinkEntity.class, entity.getGroupId()) == null) em.persist(entity);  // ← idempotent
    }
    em.flush();
    return result;
}
```

Verified end-to-end against a real Keycloak + real OpenLDAP with the built jar (same `myGroup` pre-created as a local realm group, same LDAP tree, only the extension jar differs):

| Extension jar | Sync response | `groups-with-link/count?link=…` | Groups-to-Roles list |
|---|---|---|---|
| ⬅️ `main` (without fix) | `added=0, updated=1` | **0** | empty (RD-2013) |
| ✅ this PR | `added=0, updated=1` | **1** | lists the linked group |

Same `updated=1, added=0` signature identity-ui saw on the RD-2013 test platform.

### 🔍 Review focus

- 🔴 **Critical** — `src/main/java/…/GroupWithLinkLDAPStorageMapper.java › stagePendingLinksForAllLDAPGroups` — correctness depends on `findKcGroupByLDAPGroup(realm, null, ldapGroup)` matching the same KC group the parent's own sync matched. Verified for the default `preserve.group.inheritance=false` / `groups.path=/` (what identity-ui always sends); worth eyeballing the `preserve.group.inheritance=true` path.
- 🟡 **Moderate** — same file, persist loop — `em.find(...) == null` guard runs inside the same JPA session the parent already opened, so no new transactional surface, but the "skip if exists" branch is a policy choice (we never overwrite an existing link, even one pointing at a different federation) — flag if that's the wrong default.

### 🧪 How to test

Automated:
```bash
mvn test -Dtest='GroupWithLinkTest#existing_kc_group_with_same_name_should_be_linked_on_sync'
```
The new test pre-creates a local KC group named `myGroup`, runs sync against an OpenLDAP container seeded with an identical `cn=myGroup,ou=groups,…`, and asserts the link row is written; a second sync must leave the count at 1.

Manual (reproduces RD-2013's exact conditions):
1. Deploy the built extension jar (`target/keycloak-extensions.jar`) into a Keycloak realm that has at least one local group whose name matches an LDAP group under the mapper's configured `groups.dn`.
2. `POST /admin/realms/{realm}/user-storage/{providerId}/mappers/{mapperId}/sync?direction=fedToKeycloak` — expect `2xx` with `updated>=1`.
3. `GET /admin/realms/{realm}/groups-with-link/count?link={providerId}` — before the fix returns `{"count":0}`; with the fix returns the number of matched groups.
4. Repeat step 2 to verify idempotence — the count from step 3 must not change.

### 🔗 References

- [RD-2013](https://scality.atlassian.net/browse/RD-2013) — `[RING 9.5.3] sync group failed when adding new Identity Provider`. Reported by Maria Dubelevich against `ring_9.5.3_pw5`; observed on `13.49.51.146` PTF with 7 pre-existing local groups colliding with the AD `ou=groups` tree.
- Consumer call site: [`identity-ui @ ui/src/components/identity-provider/GroupToRolesMapping.tsx:46`](https://github.com/scality/identity-ui/blob/0.41.0/ui/src/components/identity-provider/GroupToRolesMapping.tsx#L46) — `listGroups({ federationLink: providerId })` — the query that returned `[]` before the fix.

<details><summary>What changed</summary>

`GroupWithLinkLDAPStorageMapper.java` — `syncDataFromFederationProviderToKeycloak` now runs a reconciliation pass (`stagePendingLinksForAllLDAPGroups`) after `super.sync()` so LDAP groups matched to pre-existing KC groups by name also get a link row. Persist step became an upsert (`em.find` before `em.persist`). Backing store for pending links switched from `List` to `LinkedHashMap` keyed on `groupId`, so `createKcGroup` and the new reconciliation can't stage the same group twice.

`GroupWithLinkTest.java` — added `existing_kc_group_with_same_name_should_be_linked_on_sync`: real openldap Testcontainer + real Keycloak + built extension jar; pre-creates a local `myGroup`, syncs, asserts `groups-with-link/count?link=…` returns 1 and the linked group's `federationLink` points at the provider. Second sync must keep count at 1.

</details>

[RD-2013]: https://scality.atlassian.net/browse/RD-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ