### PR TITLE
fix(group-federation-link): run link reconciliation in a fresh transaction

### DIFF
--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -3,6 +3,8 @@ package com.scality.keycloak.groupFederationLink;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
@@ -51,17 +53,19 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
     // super's sync links only groups it creates; groups matched to existing KC groups
     // by name are skipped, so reconcile a link for every LDAP group here. Must use a
     // fresh session: super's inner transactions leave the outer session's JDBC
-    // connection closed (Agroal "Closing open connection(s) prior to commit").
+    // connection closed (Agroal "Closing open connection(s) prior to commit"), which
+    // also rules out calling super.findKcGroupByLDAPGroup (it runs on that session).
     private void reconcileAndPersistLinks(KeycloakSession innerSession, String realmId) {
         RealmModel innerRealm = innerSession.realms().getRealm(realmId);
         EntityManager em = innerSession.getProvider(JpaConnectionProvider.class).getEntityManager();
+        GroupMapperConfig config = new GroupMapperConfig(mapperModel);
 
-        String groupNameAttr = mapperModel.getConfig()
-                .getFirst(GroupMapperConfig.GROUP_NAME_LDAP_ATTRIBUTE);
-        List<LDAPObject> ldapGroups = getAllLDAPGroups(false);
-        for (LDAPObject ldapGroup : ldapGroups) {
-            String groupName = ldapGroup.getAttributeAsString(groupNameAttr);
-            GroupModel kcGroup = innerSession.groups().getGroupByName(innerRealm, null, groupName);
+        GroupModel groupsPathGroup = config.isTopLevelGroupsPath() ? null
+                : KeycloakModelUtils.findGroupByPath(innerSession, innerRealm, config.getGroupsPath());
+
+        for (LDAPObject ldapGroup : getAllLDAPGroups(false)) {
+            String groupName = ldapGroup.getAttributeAsString(config.getGroupNameLdapAttribute());
+            GroupModel kcGroup = findKcGroup(innerSession, innerRealm, config, groupsPathGroup, groupName);
             if (kcGroup != null) {
                 stagePendingLink(kcGroup);
             }
@@ -73,6 +77,37 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
             }
         }
         em.flush();
+    }
+
+    // Mirrors GroupLDAPStorageMapper.findKcGroupByLDAPGroup, but resolved against the
+    // fresh session: match anywhere under the groups path when inheritance is preserved,
+    // otherwise a direct child of it.
+    private GroupModel findKcGroup(KeycloakSession session, RealmModel realm, GroupMapperConfig config,
+            GroupModel groupsPathGroup, String groupName) {
+        if (config.isPreserveGroupsInheritance()) {
+            return allKcGroupsUnder(realm, groupsPathGroup)
+                    .filter(group -> Objects.equals(group.getName(), groupName))
+                    .findFirst()
+                    .orElse(null);
+        }
+        return session.groups().getGroupByName(realm, groupsPathGroup, groupName);
+    }
+
+    private static Stream<GroupModel> allKcGroupsUnder(RealmModel realm, GroupModel topParentGroup) {
+        Stream<GroupModel> allGroups = realm.getGroupsStream();
+        if (topParentGroup == null) {
+            return allGroups;
+        }
+        return allGroups.filter(group -> {
+            GroupModel parent = group.getParent();
+            while (parent != null) {
+                if (parent.getId().equals(topParentGroup.getId())) {
+                    return true;
+                }
+                parent = parent.getParent();
+            }
+            return false;
+        });
     }
 
     private void stagePendingLink(GroupModel groupModel) {

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -7,11 +7,14 @@ import java.util.Map;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupMapperConfig;
 import org.keycloak.storage.user.SynchronizationResult;
 
 import jakarta.persistence.EntityManager;
@@ -25,26 +28,15 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
         super(mapperModel, ldapProvider, factory);
     }
 
-    private EntityManager getEntityManager() {
-        return session.getProvider(JpaConnectionProvider.class).getEntityManager();
-    }
-
     @Override
     public SynchronizationResult syncDataFromFederationProviderToKeycloak(RealmModel realm) {
         pendingLinks.clear();
         SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
-        stagePendingLinksForAllLDAPGroups(realm);
 
-        if (!pendingLinks.isEmpty()) {
-            EntityManager em = getEntityManager();
-            for (GroupFederationLinkEntity entity : pendingLinks.values()) {
-                if (em.find(GroupFederationLinkEntity.class, entity.getGroupId()) == null) {
-                    em.persist(entity);
-                }
-            }
-            em.flush();
-            pendingLinks.clear();
-        }
+        KeycloakModelUtils.runJobInTransaction(
+                ldapProvider.getSession().getKeycloakSessionFactory(),
+                innerSession -> reconcileAndPersistLinks(innerSession, realm.getId()));
+        pendingLinks.clear();
 
         return result;
     }
@@ -60,14 +52,32 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
     // that match by name go through a private update path we can't hook. Reconcile
     // here so every LDAP group ends up with a federation link, whether created now
     // or matched to a pre-existing local group.
-    private void stagePendingLinksForAllLDAPGroups(RealmModel realm) {
+    //
+    // The whole reconcile+persist runs in a fresh Keycloak session because the outer
+    // sync session's JDBC connection is already closed by the time super returns
+    // (Agroal warns "Closing open connection(s) prior to commit"), so any JPA work
+    // reusing that session hits "Connection is closed".
+    private void reconcileAndPersistLinks(KeycloakSession innerSession, String realmId) {
+        RealmModel innerRealm = innerSession.realms().getRealm(realmId);
+        EntityManager em = innerSession.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+        String groupNameAttr = mapperModel.getConfig()
+                .getFirst(GroupMapperConfig.GROUP_NAME_LDAP_ATTRIBUTE);
         List<LDAPObject> ldapGroups = getAllLDAPGroups(false);
         for (LDAPObject ldapGroup : ldapGroups) {
-            GroupModel kcGroup = findKcGroupByLDAPGroup(realm, null, ldapGroup);
+            String groupName = ldapGroup.getAttributeAsString(groupNameAttr);
+            GroupModel kcGroup = innerSession.groups().getGroupByName(innerRealm, null, groupName);
             if (kcGroup != null) {
                 stagePendingLink(kcGroup);
             }
         }
+
+        for (GroupFederationLinkEntity entity : pendingLinks.values()) {
+            if (em.find(GroupFederationLinkEntity.class, entity.getGroupId()) == null) {
+                em.persist(entity);
+            }
+        }
+        em.flush();
     }
 
     private void stagePendingLink(GroupModel groupModel) {

--- a/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
+++ b/src/main/java/com/scality/keycloak/groupFederationLink/GroupWithLinkLDAPStorageMapper.java
@@ -48,15 +48,10 @@ public class GroupWithLinkLDAPStorageMapper extends GroupLDAPStorageMapper {
         return groupModel;
     }
 
-    // Parent's sync only calls createKcGroup for brand-new groups; existing KC groups
-    // that match by name go through a private update path we can't hook. Reconcile
-    // here so every LDAP group ends up with a federation link, whether created now
-    // or matched to a pre-existing local group.
-    //
-    // The whole reconcile+persist runs in a fresh Keycloak session because the outer
-    // sync session's JDBC connection is already closed by the time super returns
-    // (Agroal warns "Closing open connection(s) prior to commit"), so any JPA work
-    // reusing that session hits "Connection is closed".
+    // super's sync links only groups it creates; groups matched to existing KC groups
+    // by name are skipped, so reconcile a link for every LDAP group here. Must use a
+    // fresh session: super's inner transactions leave the outer session's JDBC
+    // connection closed (Agroal "Closing open connection(s) prior to commit").
     private void reconcileAndPersistLinks(KeycloakSession innerSession, String realmId) {
         RealmModel innerRealm = innerSession.realms().getRealm(realmId);
         EntityManager em = innerSession.getProvider(JpaConnectionProvider.class).getEntityManager();


### PR DESCRIPTION
**TL;DR** — LDAP group sync was throwing `Connection is closed` on Postgres (surfaced to the RING wizard as "Failed to sync the LDAP groups"); this runs the federation-link reconciliation in a fresh transaction so it no longer reuses the outer session's already-closed JDBC connection.

### Context / Why

RD-2013: on RING 9.5.3 RC2, adding an LDAP identity provider fails at the "Sync groups" step and the operator can't map groups to roles. RC2 ships `keycloak-extensions 1.5.5-26.2.0`, whose reconciliation pass (added to fix the *original* RD-2013 — links for pre-existing same-named groups) reused the outer sync session's `EntityManager`. On the customer/PTF Postgres backend that connection is already closed by the time it runs, so the whole sync aborts. The earlier fix passed CI and a prior PTF because both were H2-backed, which doesn't exhibit the same connection lifecycle.

### 🧩 Approach

The connection lifecycle is the whole story — where 1.5.5 (🟥) and this PR (🟩) diverge:

```mermaid
flowchart TD
    A[syncData called<br/>outer session opens JDBC connection] --> B[super.sync runs<br/>each group in its own runJobInTransaction]
    B --> C[Agroal returns + closes the outer connection<br/>WARN: Closing open connection s prior to commit]
    C --> D{reconcile + persist federation links}
    D -->|"1.5.5: reuse outer EntityManager"| E[SELECT GROUP_FEDERATION_LINK<br/>on the closed connection]:::removed
    E --> F["Connection is closed → HTTP 400 UnknownError<br/>wizard: Failed to sync the LDAP groups"]:::removed
    D -->|"this PR: runJobInTransaction"| G[fresh session + live connection]:::added
    G --> H["7 links persisted → HTTP 200<br/>wizard: Sync groups Success"]:::added
    classDef removed fill:#8a2f2f,stroke:#e06666,color:#ffffff
    classDef added fill:#1f7a3d,stroke:#3fb56b,color:#ffffff
```

Legend: 🟥 red = the 1.5.5 path that fails · 🟩 green = the path this PR takes. The fix opens a fresh session (and live connection) via `KeycloakModelUtils.runJobInTransaction` — the exact pattern the parent mapper uses for its own per-group work — and looks groups up with `session.groups().getGroupByName` on that fresh realm rather than the parent's `findKcGroupByLDAPGroup` bound to the stale one.

Before — reuses the outer (closed) session:
```java
SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
stagePendingLinksForAllLDAPGroups(realm);
if (!pendingLinks.isEmpty()) {
    EntityManager em = getEntityManager();   // ← outer session, connection already closed on Postgres
    for (GroupFederationLinkEntity entity : pendingLinks.values()) {
        if (em.find(GroupFederationLinkEntity.class, entity.getGroupId()) == null) em.persist(entity);
    }
    em.flush();
}
```

After — fresh transaction, live connection:
```java
SynchronizationResult result = super.syncDataFromFederationProviderToKeycloak(realm);
KeycloakModelUtils.runJobInTransaction(                                          // ← fresh session
    ldapProvider.getSession().getKeycloakSessionFactory(),
    innerSession -> reconcileAndPersistLinks(innerSession, realm.getId()));
```

### ✅ Verification — RC2 PTF, end-to-end wizard

Verified on the RC2 PTF (`16.192.83.118`, Postgres, Keycloak 26.2.4, real AD at `10.160.250.10`) by swapping the jar in place — same box, same LDAP, same wizard inputs, only the extension jar differs:

| Extension jar | Sync (identity-ui path) | `groups-with-link/count?link=…` | Wizard result |
|---|---|---|---|
| `1.5.5-26.2.0` (RC2) | `HTTP 400 {"errorMessage":"UnknownError"}` | 0 | 🔴 "Failed to sync the LDAP groups" |
| this PR | `HTTP 200 added=0 updated=7 failed=0` (255 ms) | 7 | 🟢 all 8 apply-config steps green; 7 groups linked |

**Sync groups — before (1.5.5) vs after (this PR):**

| Before | After |
|---|---|
| ![Before — red Failed to sync banner](https://github.com/user-attachments/assets/ed5eb18f-7b04-42a1-b6ba-f5e6111a0e1e) | ![After — green Sync finished successfully](https://github.com/user-attachments/assets/02458061-2bcb-4901-9b9f-a7ca0eb4b89b) |

Then the full "Add Identity Provider" wizard from scratch, all six steps, ending with a role actually attached — the exact flow RD-2013 says is broken:

**Step 5 — Groups to Roles Mapping** lists all 7 groups (the screen the ticket reported empty):

![Step 5 — 7 groups listed](https://github.com/user-attachments/assets/e8893ecd-b267-4c20-8823-4984d45354c8)

**Step 6 — Review & Apply** — `RING_Admins` → `RING Admin`, attachment status Success (confirmed in Keycloak: the group carries the `RING Admin` realm role afterwards):

![Step 6 — RING_Admins to RING Admin, Success](https://github.com/user-attachments/assets/4b9c0211-cb1c-43fc-811e-c61b7d533a2a)

### 🔍 Review focus

- 🔴 **Critical** — `GroupWithLinkLDAPStorageMapper › syncDataFromFederationProviderToKeycloak` — the transaction boundary is the whole fix. Confirm `runJobInTransaction` is the right factory (`ldapProvider.getSession().getKeycloakSessionFactory()`) and that reading `pendingLinks` (populated during super's run, on `this`) from inside the fresh session is intended.
- 🟡 **Moderate** — `GroupWithLinkLDAPStorageMapper › findKcGroup` / `allKcGroupsUnder` — these transcribe the parent's `findKcGroupByLDAPGroup` / `getAllKcGroups` semantics (honor `groups.path` as lookup parent; match anywhere under it when `preserve.group.inheritance=true`, else a direct child) onto the fresh session, since the parent's own method runs on the closed mapper session. Worth confirming the transcription stays faithful across Keycloak upgrades. **Runtime-verified only for the product config** (`preserve=false`, `groups.path=/`), which is behaviorally identical to the lookup in the previously-verified build; the `preserve=true` / non-root-path branches are verified by inspection against 26.2.0 source, not exercised on a live nested-group LDAP.

### 🧪 How to test

Requires a **Postgres-backed** Keycloak (H2/dev-mode won't reproduce the connection-close). Against a realm with local groups whose names match LDAP groups under the mapper's `groups.dn`:
1. `POST /admin/realms/{realm}/user-storage/{providerId}/mappers/{mapperId}/sync?direction=fedToKeycloak` — expect `200` with `updated>=1` (was `400 UnknownError` on 1.5.5).
2. `GET /admin/realms/{realm}/groups-with-link/count?link={providerId}` — expect the matched-group count (was `0`).
3. From the RING Supervisor wizard: Add Identity Provider → the "Sync groups" apply step shows Success and the Groups-to-Roles step lists the groups.

### 🔗 References

- [RD-2013](https://scality.atlassian.net/browse/RD-2013) — `[RING 9.5.3] sync group failed when adding new Identity Provider`. Reproduced on RC2 (`ring_9.5.3_rc2`) PTF `16.192.83.118`.
- [#25](https://github.com/scality/keycloak-extensions/pull/25) — the 1.5.5 fix this repairs; correct on mechanism (link pre-existing same-named groups) but reused the outer session's connection.

<details><summary>What changed</summary>

`GroupWithLinkLDAPStorageMapper.java` — the reconcile + upsert loop moved out of the outer `syncDataFromFederationProviderToKeycloak` body into a new `reconcileAndPersistLinks(KeycloakSession, realmId)` run via `KeycloakModelUtils.runJobInTransaction`, so it executes on a fresh session/connection. Group lookup switched from the parent's `findKcGroupByLDAPGroup` to `session.groups().getGroupByName` on the fresh realm. The idempotent `em.find(...) == null` guard before `persist` is retained. `getEntityManager()` helper removed (the EM now comes from the inner session). No behavior change for the create path or the link-uniqueness semantics.

</details>

[RD-2013]: https://scality.atlassian.net/browse/RD-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ